### PR TITLE
Refactor/#129 네이버지도 지원 중단으로 인한 업데이트

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       const ncpKeyId = import.meta.env.VITE_NAVER_MAP_API;
 
       if (!ncpKeyId) {
-        console.error("Naver Map API key (VITE_NAVER_MAP_KEY) is missing");
+        console.error("Naver Map API key (VITE_NAVER_MAP_API) is missing");
       } else {
         const script = document.createElement("script");
         script.src = `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${ncpKeyId}`;

--- a/index.html
+++ b/index.html
@@ -25,6 +25,18 @@
       <span style="font-weight: bold;">택시팟</span>
     </div>
     <script type="module" src="/src/main.tsx"></script>
+    <script type="module">
+      const ncpKeyId = import.meta.env.VITE_NAVER_MAP_API;
+
+      if (!ncpKeyId) {
+        console.error("Naver Map API key (VITE_NAVER_MAP_KEY) is missing");
+      } else {
+        const script = document.createElement("script");
+        script.src = `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${ncpKeyId}`;
+        script.async = true;
+        document.head.appendChild(script);
+      }
+    </script>
     <script src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js" integrity="sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { NavermapsProvider } from 'react-naver-maps';
 import { Analytics } from '@vercel/analytics/react';
 import Router from '@/Router.tsx';
 import { useGetRefreshAccessTokenQuery } from '@/api/userApi.ts';
@@ -9,7 +8,6 @@ import GlobalStyle from '@/styles/GlobalStyle.ts';
 import { ErrorBoundary } from '@suspensive/react';
 import ErrorBoundaryFallback from '@/ErrorBoundaryFallback.tsx';
 
-const naverMapApi = import.meta.env.VITE_NAVER_MAP_API;
 const kakaoJsKey = import.meta.env.VITE_KAKAO_JS_KEY;
 
 window.Kakao.init(kakaoJsKey);
@@ -39,10 +37,8 @@ function App() {
   return (
     <ErrorBoundary fallback={ErrorBoundaryFallback}>
       <Analytics />
-      <NavermapsProvider ncpClientId={naverMapApi}>
         <GlobalStyle />
         <Router />
-      </NavermapsProvider>
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## 📌 간단 설명
close #129 
현재 사용중인 [react-naver-maps](https://zeakd.github.io/react-naver-maps/)의 NavermapsProvider를 사용하는 방식에서 직접 script를 로드하는 방식으로 임시 변경했습니다.
현재 사용 중인 react-naver-maps 버전에서는 ncpKeyId를 지원하지 않아, ([해당 pr](https://github.com/zeakd/react-naver-maps/pull/123))이 머지되기 전까지는 직접 script를 통해 Naver Maps API를 불러오는 방식으로 대체합니다.
추후 react-naver-maps의 업데이트가 적용되면 다시 NavermapsProvider 방식으로 복구할 예정입니다.

## ✅ 변경 내용

- NavermapsProvider 삭제
- index.html에서 직접 script를 로드