### PR TITLE
Feat/#131 react-naver-maps 버전 업데이트,  NavermapsProvider 사용

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,18 +25,6 @@
       <span style="font-weight: bold;">택시팟</span>
     </div>
     <script type="module" src="/src/main.tsx"></script>
-    <script type="module">
-      const ncpKeyId = import.meta.env.VITE_NAVER_MAP_API;
-
-      if (!ncpKeyId) {
-        console.error("Naver Map API key (VITE_NAVER_MAP_API) is missing");
-      } else {
-        const script = document.createElement("script");
-        script.src = `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${ncpKeyId}`;
-        script.async = true;
-        document.head.appendChild(script);
-      }
-    </script>
     <script src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js" integrity="sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12695,9 +12695,9 @@
       }
     },
     "node_modules/react-naver-maps": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/react-naver-maps/-/react-naver-maps-0.1.3.tgz",
-      "integrity": "sha512-J2AD+MMn33NQ0RH3ldn4kG0ehV9Ao+16/w2kw4XilWl/xWI8mu2DnHUJNaxWBu7S0JSEIsFJuUp7JfZ48wH8kw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/react-naver-maps/-/react-naver-maps-0.1.4.tgz",
+      "integrity": "sha512-U3JvIjYEZJCLdKLPES2ANgefqI+r5N3xcszmSoaG7H8SU5KHIMYpnER+NViD7dws/GcARkbdc/v5ieuVNfxaIA==",
       "license": "MIT",
       "dependencies": {
         "camelcase": "^5.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,10 @@ import { setIsLogin } from '@/domains/MyProfile/Slice/userSlice.ts';
 import GlobalStyle from '@/styles/GlobalStyle.ts';
 import { ErrorBoundary } from '@suspensive/react';
 import ErrorBoundaryFallback from '@/ErrorBoundaryFallback.tsx';
+import {NavermapsProvider} from "react-naver-maps";
 
 const kakaoJsKey = import.meta.env.VITE_KAKAO_JS_KEY;
+const naverMapApi = import.meta.env.VITE_NAVER_MAP_API;
 
 window.Kakao.init(kakaoJsKey);
 
@@ -37,8 +39,10 @@ function App() {
   return (
     <ErrorBoundary fallback={ErrorBoundaryFallback}>
       <Analytics />
+      <NavermapsProvider ncpKeyId={naverMapApi}>
         <GlobalStyle />
         <Router />
+      </NavermapsProvider>
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## 📌 간단 설명
관련 이슈: #131 
관련 이전 pr: #130 
react-naver-maps 버전 업데이트로 ncpKeyId를 지원함으로, 다시 NavermapsProvider 통해 Naver Maps API를 불러오는 방식으로 대체합니다.

## ✅ 변경 내용
- index.html의 map 관련 인라인 스크립트를 제거
- NavermapsProvider 적용