### PR TITLE
refactor: 모바일 브라우저(주소창) 디자인을 위해 height 단위를 vh에서 svh로 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <div id="root"></div>
     <div id="splash"
             style="
-    height: 100vh;
+    height: 100svh;
     display: flex;
     justify-content: center;
     flex-direction: column;

--- a/src/components/common/Layout/Layout.style.ts
+++ b/src/components/common/Layout/Layout.style.ts
@@ -4,7 +4,7 @@ export const Container = styled.div`
   margin: 0 auto;
   max-width: 450px;
   width: 100%;
-  height: 100vh;
+  height: 100svh;
 
   display: flex;
   justify-content: center;

--- a/src/components/common/SearchList/SearchList.style.ts
+++ b/src/components/common/SearchList/SearchList.style.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const SearchListContainer = styled.ul`
-  height: calc(100vh - (var(--header-height)));
+  height: calc(100svh - (var(--header-height)));
   border-top: 1px solid var(--color-gray-300);
 
   overflow-y: auto;

--- a/src/domains/Home/components/Map/Map.style.ts
+++ b/src/domains/Home/components/Map/Map.style.ts
@@ -6,7 +6,7 @@ export const Main = styled.main`
   position: relative;
   .map-wrapper {
     width: 100%;
-    height: calc(100vh - (var(--header-height) + var(--footer-height)));
+    height: calc(100svh - (var(--header-height) + var(--footer-height)));
   }
   ${MarkerContainerStyle}
 


### PR DESCRIPTION
## 📌 간단 설명

#133 
모바일 브라우저에서 접속 시 하단 네비게이션 사라짐 해결

## ✅ 변경 내용

- css `100vh` ➡️ `100svh`

<img src="https://github.com/user-attachments/assets/461ebc8a-278f-4aa8-83ec-c19193e55de9" alt="before" width="200"/>

<img src="https://github.com/user-attachments/assets/fe2a9cf3-cb3e-4d8d-8e20-22fc6b50f033" alt="after" width="200"/>


