### PR TITLE
fix: reactNativePostMessage 임포트 및 사용 주석 처리

### DIFF
--- a/src/domains/Home/Page/index.tsx
+++ b/src/domains/Home/Page/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { useNavermaps } from 'react-naver-maps';
 
 import { useLazyGetPostsQuery } from '@/api/postApi.ts';
-import reactNativePostMessage from '@/utils/reactNativePostMessage.ts';
+// import reactNativePostMessage from '@/utils/reactNativePostMessage.ts';
 import { defaultLocation } from '@/utils/getCurrentlocation.ts';
 import { Location } from '@/types';
 
@@ -101,9 +101,9 @@ const HomePage = () => {
           <TaxiIcon />
         </HeaderItem>
         <button
-          onClick={() => {
-            reactNativePostMessage('like_knu');
-          }}
+          // onClick={() => {
+          //   reactNativePostMessage('like_knu');
+          // }}
         >
           <KnuLogoIcon />
         </button>

--- a/src/domains/Login/Page/LoginLoadingPage.tsx
+++ b/src/domains/Login/Page/LoginLoadingPage.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
-import reactNativePostMessage from '@/utils/reactNativePostMessage.ts';
+//import reactNativePostMessage from '@/utils/reactNativePostMessage.ts';
 import { useGetAccessTokenQuery } from '@/api/userApi.ts';
 import { setIsLogin } from '@/domains/MyProfile/Slice/userSlice.ts';
 import useErrorHandle from '@/hooks/useErrorHandle.ts';
@@ -26,7 +26,7 @@ const LoginLoadingPage = () => {
   useEffect(() => {
     if (!isTokenLoading && isTokenSuccess) {
       dispatch(setIsLogin(true));
-      reactNativePostMessage('push_notification');
+      // reactNativePostMessage('push_notification');
       navigate('/', { replace: true });
     } else if (isTokenError) {
       alert('로그인에 실패했습니다.');


### PR DESCRIPTION
## 📌 간단 설명
모바일로 네이티브의 웹뷰가 아닌 브라우저 환경에서 로그인 오류
로그인 성공 시 reactNativePostMessage 함수(window.ReactNativeWebView.postMessage) 실행으로 인한 오류
현재 공주대처럼 앱에서 사용되지 않으므로 앱과 통신 기능이 필요 없음
이에 따라 해당 로직 주석 처리


## ✅ 변경 내용

- #135 
