### PR TITLE
feat/ 카카오 택시 앱 링크 포맷팅 함수 추가 및 관련 코드 수정

### DIFF
--- a/src/domains/PostDetail/Page/PostDetailContainer.tsx
+++ b/src/domains/PostDetail/Page/PostDetailContainer.tsx
@@ -6,13 +6,13 @@ import {
   formatNaverMapUrl,
   getWebNaverMapUrl,
 } from '../utiils/formatNaverMapUrl.ts';
+import { formatKakaoTaxiUrl } from '../utiils/formatKakaoTaxiUrl.ts';
 import formatDateForDetailPost from '@/utils/date/formatDateForDetailPost.ts';
 import openOtherApp from '../utiils/openOtherMapApp.ts';
 
 import {
   NAVER_MAP_IOS_URL,
   NAVER_MAP_ANDROID_URL,
-  KAKAO_TAXI_APP_LINK,
   KAKAO_TAXI_IOS_URL,
   KAKAO_TAXI_ANDROID_URL,
 } from '../constants';
@@ -75,6 +75,16 @@ const PostDetailContainer = () => {
   };
 
   const handleOpenKakaoTaxiApp = () => {
+    if (data.taxi.route.length === 0) return;
+    const route = data.taxi.route;
+
+    const destination: Omit<Place, 'name'> = {
+      lat: route.at(-1)!.latitude,
+      lng: route.at(-1)!.longitude,
+    };
+
+    const KAKAO_TAXI_APP_LINK = formatKakaoTaxiUrl(destination);
+
     openOtherApp(
       KAKAO_TAXI_APP_LINK,
       KAKAO_TAXI_IOS_URL,

--- a/src/domains/PostDetail/constants/index.ts
+++ b/src/domains/PostDetail/constants/index.ts
@@ -3,7 +3,6 @@ export const NAVER_MAP_IOS_URL =
 export const NAVER_MAP_ANDROID_URL =
   'https://play.google.com/store/apps/details?id=com.nhn.android.nmap&hl=ko';
 
-export const KAKAO_TAXI_APP_LINK = 'kakaot://';
 export const KAKAO_TAXI_IOS_URL = 'https://apps.apple.com/kr/app/id981110422';
 export const KAKAO_TAXI_ANDROID_URL =
   'https://play.google.com/store/apps/details?id=com.kakao.taxi';

--- a/src/domains/PostDetail/utiils/formatKakaoTaxiUrl.ts
+++ b/src/domains/PostDetail/utiils/formatKakaoTaxiUrl.ts
@@ -1,0 +1,5 @@
+import { Place } from '../types';
+
+export const formatKakaoTaxiUrl = (destination: Omit<Place, 'name'>) => {
+  return `kakaot://taxi?dest_lat=${destination.lat}&dest_lng=${destination.lng}`;
+};


### PR DESCRIPTION
## 📌 간단 설명
- 기존 카카오택시 딥링크 → 앱 메인화면이 아닌, 출발지(**호출 시점 사용자의 위치**)부터 도착지까지 설정된 호출 화면으로 이동하도록 개선


## ✅ 변경 내용
- formatKakaoTaxiUrl 함수 생성
- 도착지 좌표를 포함한 딥링크 URL 생성으로 정확한 호출 화면 진입 가능