### PR TITLE
Fix/#145

### DIFF
--- a/src/domains/PostDetail/components/ParticipantsBox/index.tsx
+++ b/src/domains/PostDetail/components/ParticipantsBox/index.tsx
@@ -5,7 +5,7 @@ import { Participant } from '@/types/post.ts';
 const ParticipantsBox = ({ participants }: { participants: Participant[] }) => {
   return (
     <ParticipantsBoxContainer>
-      {participants // 배열의 복사본을 생성
+      {[...participants] // 배열의 복사본을 생성
         .sort((a) => (a.role === 'HOST' ? -1 : 1)) // 'HOST'인 데이터를 앞으로 이동
         .map((item) => (
           <UserContainer

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -28,7 +28,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "types": ["vitest/globals","vitest/jsdom"]
+    "types": ["vitest/globals","vitest/jsdom", "navermaps"]
   },
   "include": ["src/**/*", "global.d.ts", "vitest.setup.ts"]
 }


### PR DESCRIPTION
## 📌 간단 설명
- #145 
- 참여자가 2명 이상일 때 ParticipantsBox 에서 오류 발생 해결
- 원인: sort() 호출 시 원본 배열을 직접 수정하려다 TypeError 발생
  - TypeError: Cannot assign to read only property '0' of object '[object Array]'
  - [관련 이슈 - Redux Toolkit](https://github.com/reduxjs/redux-toolkit/issues/1437)
## ✅ 변경 내용
-  정렬 전 배열 복사본을 만들어 원본 변경 없이 렌더링되도록 수정 8e627835fb61c7064d9816323e639fae3cbf7d6b
- tsconfig.app.json에 navermaps 타입 추가 1334c9ea9879d5d1d073614a3e95b73d32158540
